### PR TITLE
Criando as estatísticas de mês e ano para task

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "sea-orm",
  "sea-orm-migration",
  "serde",
+ "serde_json",
  "validator",
 ]
 
@@ -2530,9 +2531,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.142"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -18,3 +18,4 @@ pbkdf2 = { version = "0.12", features = ["simple"] }
 rand_core = { version = "0.6", features = ["std"] }
 validator = { version = "0.18", features = ["derive"] }
 chrono = "0.4.41"
+serde_json = "1.0.143"

--- a/backend/src/controller/reminder.rs
+++ b/backend/src/controller/reminder.rs
@@ -1,8 +1,6 @@
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::State;
-use sea_orm::EntityTrait;
-
 use crate::controller::auth::UserClaim;
 use crate::db::Pool;
 use crate::dto::reminder_dto::reminder_DTO;

--- a/backend/src/controller/task.rs
+++ b/backend/src/controller/task.rs
@@ -6,7 +6,7 @@ use crate::controller::auth::UserClaim;
 use crate::db::Pool;
 use crate::dto::taskDTO::TaskDto;
 use crate::entity::task;
-use crate::service::task_service::{delete_task_db, get_all_tasks_db, get_task_by_id_db, register_task_db, update_task_db, get_tasks_by_user_id_db, TaskError, update_status_task_db, get_task_stats_year_db};
+use crate::service::task_service::{delete_task_db, get_all_tasks_db, get_task_by_id_db, register_task_db, update_task_db, get_tasks_by_user_id_db, TaskError, update_status_task_db, get_task_stats_year_db, get_task_stats_month_db};
 use crate::dto::taskStatusDTO::StatusUpdateDto;
 
 #[get("/")]
@@ -55,6 +55,24 @@ pub async fn get_task_stats_year(
     })?;
 
     match get_task_stats_year_db(db, user_id, year).await {
+        Ok(stats) => Ok(Json(stats)),
+        Err(TaskError::DatabaseError(msg)) => Err((Status::InternalServerError, msg)),
+        _ => Err((Status::InternalServerError, "Failed to get task statistics".to_string())),
+    }
+}
+
+#[get("/stats/<year>/<month>")]
+pub async fn get_task_stats_month(
+    db: &State<Pool>,
+    token: UserClaim,
+    year: i32,
+    month: i32,
+) -> Result<Json<Value>, (Status, String)> {
+    let user_id = token.get_id().parse::<i32>().map_err(|_| {
+        (Status::BadRequest, "Invalid token: user_id is not valid".to_string())
+    })?;
+
+    match get_task_stats_month_db(db, user_id, year, month).await {
         Ok(stats) => Ok(Json(stats)),
         Err(TaskError::DatabaseError(msg)) => Err((Status::InternalServerError, msg)),
         _ => Err((Status::InternalServerError, "Failed to get task statistics".to_string())),

--- a/backend/src/controller/task.rs
+++ b/backend/src/controller/task.rs
@@ -4,12 +4,8 @@ use serde_json::Value;
 use rocket::State;
 use crate::controller::auth::UserClaim;
 use crate::db::Pool;
-use crate::dto::authDTO::AuthDto;
-use crate::dto::CreateNote;
 use crate::dto::taskDTO::TaskDto;
-use crate::entity::{notes, task};
-use crate::service::auth_service;
-use crate::repository::auth_repository::UserError;
+use crate::entity::task;
 use crate::service::task_service::{delete_task_db, get_all_tasks_db, get_task_by_id_db, register_task_db, update_task_db, get_tasks_by_user_id_db, TaskError, update_status_task_db, get_task_stats_year_db};
 use crate::dto::taskStatusDTO::StatusUpdateDto;
 

--- a/backend/src/controller/task.rs
+++ b/backend/src/controller/task.rs
@@ -1,5 +1,6 @@
 use rocket::http::Status;
 use rocket::serde::json::Json;
+use serde_json::Value;
 use rocket::State;
 use crate::controller::auth::UserClaim;
 use crate::db::Pool;
@@ -9,7 +10,7 @@ use crate::dto::taskDTO::TaskDto;
 use crate::entity::{notes, task};
 use crate::service::auth_service;
 use crate::repository::auth_repository::UserError;
-use crate::service::task_service::{delete_task_db, get_all_tasks_db, get_task_by_id_db, register_task_db, update_task_db, get_tasks_by_user_id_db, TaskError, update_status_task_db};
+use crate::service::task_service::{delete_task_db, get_all_tasks_db, get_task_by_id_db, register_task_db, update_task_db, get_tasks_by_user_id_db, TaskError, update_status_task_db, get_task_stats_year_db};
 use crate::dto::taskStatusDTO::StatusUpdateDto;
 
 #[get("/")]
@@ -44,6 +45,23 @@ pub async fn get_tasks_by_user_id(
         Ok(tasks) => Ok(Json(tasks)),
         Err(TaskError::DatabaseError(msg)) => Err((Status::InternalServerError, msg)),
         _ => Err((Status::InternalServerError, "Failed to get user tasks".to_string())),
+    }
+}
+
+#[get("/stats/<year>")]
+pub async fn get_task_stats_year(
+    db: &State<Pool>,
+    token: UserClaim,
+    year: i32,
+) -> Result<Json<Value>, (Status, String)> {
+    let user_id = token.get_id().parse::<i32>().map_err(|_| {
+        (Status::BadRequest, "Invalid token: user_id is not valid".to_string())
+    })?;
+
+    match get_task_stats_year_db(db, user_id, year).await {
+        Ok(stats) => Ok(Json(stats)),
+        Err(TaskError::DatabaseError(msg)) => Err((Status::InternalServerError, msg)),
+        _ => Err((Status::InternalServerError, "Failed to get task statistics".to_string())),
     }
 }
 

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -1,4 +1,4 @@
-use rocket::fairing::{self, AdHoc};
+use rocket::fairing::AdHoc;
 use sea_orm::{Database, DatabaseConnection};
 
 use sea_orm_migration::prelude::*;

--- a/backend/src/entity/task.rs
+++ b/backend/src/entity/task.rs
@@ -15,7 +15,7 @@ pub struct Model {
     pub begin_date: DateTimeUtc,
     pub complete_date: DateTimeUtc,
     pub category: String,
-    pub r#type: String,                     //  MeiaHora, UmaHora, Manha, Tarde, Noite
+    pub r#type: String,                     //  MeiaHora, UmaHora, DuasHoras, Manha, Tarde, Noite, Madrugada
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -9,10 +9,9 @@ mod routes;
 mod service;
 mod repository;
 
-use crate::controller::auth::{login, register, user_info};
 use dotenvy::dotenv;
 use rocket::tokio::time::{sleep, Duration};
-use rocket_cors::{AllowedHeaders, AllowedOrigins, Cors, CorsOptions};
+use rocket_cors::{AllowedHeaders, AllowedOrigins, CorsOptions};
 
 #[get("/")]
 fn index() -> &'static str {

--- a/backend/src/repository/task_repository.rs
+++ b/backend/src/repository/task_repository.rs
@@ -114,6 +114,101 @@ impl<'a> TaskRepository<'a> {
         ))
     }
 
+    pub async fn tasks_stats_month(&self, user_id: i32, year: i32, month: i32) -> Result<(i64, i64, f64, i32, i32,String, String), DbErr> {
+
+        let start_date = Utc.with_ymd_and_hms(year, month.try_into().unwrap(), 1, 0, 0, 0).unwrap();
+
+        let (next_year, next_month) = if month == 12 {
+            (year + 1, 1)
+        } else {
+            (year, month + 1)
+        };
+
+        let first_day_of_next_month = Utc.with_ymd_and_hms(next_year, next_month.try_into().unwrap(), 1, 0, 0, 0).unwrap();
+        let end_date = first_day_of_next_month - Duration::seconds(1);
+
+        // Total de tarefas do usuário no ano especificado
+        let total_tasks = task::Entity::find()
+            .filter(task::Column::UserId.eq(user_id))
+            .filter(task::Column::BeginDate.gte(start_date))
+            .filter(task::Column::BeginDate.lte(end_date))
+            .count(self.db)
+            .await?;
+
+        // Tarefas executadas no ano
+        let executed_tasks = task::Entity::find()
+            .filter(task::Column::UserId.eq(user_id))
+            .filter(task::Column::BeginDate.gte(start_date))
+            .filter(task::Column::BeginDate.lte(end_date))
+            .filter(task::Column::Status.eq("Executada"))
+            .count(self.db)
+            .await?;
+
+        // Calcular porcentagem
+        let percentage = if total_tasks > 0 {
+            (executed_tasks as f64 / total_tasks as f64) * 100.0
+        } else {
+            0.0
+        };
+
+        // 1. Buscar os detalhes das tarefas executadas
+        let executed_task_details = task::Entity::find()
+            .filter(task::Column::UserId.eq(user_id))
+            .filter(task::Column::Status.eq("Executada"))
+            .filter(task::Column::CompleteDate.gte(start_date))
+            .filter(task::Column::CompleteDate.lte(end_date))
+            .all(self.db)
+            .await?;
+
+        // 2. Inicializar os contadores para turnos e categorias
+        let mut shift_counts: HashMap<&'static str, i32> = HashMap::new();
+        let mut category_counts: HashMap<String, i32> = HashMap::new();
+
+        // 3. Iterar sobre as tarefas para contar turnos E categorias
+        for task in &executed_task_details {
+            // Lógica para contar o turno (sem alterações)
+            let hour = task.complete_date.hour();
+            let shift_name = match hour {
+                6..=11 => Some("Manhã"),
+                12..=17 => Some("Tarde"),
+                18..=23 => Some("Noite"),
+                0..=5 => Some("Madrugada"),
+                _ => None,
+            };
+            if let Some(name) = shift_name {
+                *shift_counts.entry(name).or_insert(0) += 1;
+            }
+
+            // NOVO: Lógica para contar as categorias
+            *category_counts.entry(task.category.clone()).or_insert(0) += 1;
+        }
+
+        // 4. Encontrar o turno mais produtivo
+        let most_productive_shift = shift_counts
+            .into_iter()
+            .max_by_key(|&(_, count)| count)
+            .map(|(shift_name, _)| shift_name.to_string())
+            .unwrap_or_else(|| "N/A".to_string());
+
+
+        // 5. Encontrar a categoria com a maior contagem diretamente
+        let most_used_category = category_counts
+            .into_iter()
+            .max_by_key(|&(_, count)| count)
+            .map(|(category, _)| category)
+            .unwrap_or_else(|| "N/A".to_string());
+
+        Ok((
+            total_tasks as i64,
+            executed_tasks as i64,
+            percentage,
+            year,
+            month,
+            most_productive_shift,
+            most_used_category,
+        ))
+    }
+
     pub async fn create_task(
         &self,
         task_info: &TaskDto,

--- a/backend/src/repository/task_repository.rs
+++ b/backend/src/repository/task_repository.rs
@@ -1,5 +1,5 @@
 use sea_orm::{ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, DeleteResult, DbErr, EntityTrait, IntoActiveModel, QueryFilter, Set, PaginatorTrait};
-use chrono::{Datelike, Timelike, Utc, TimeZone, Duration};
+use chrono::{Timelike, Utc, TimeZone, Duration};
 use std::collections::HashMap;
 use crate::dto::taskDTO::TaskDto;
 use crate::entity::task;

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -32,6 +32,7 @@ pub fn get_task_routes() -> Vec<rocket::Route> {
         task::delete_task,
         task::get_tasks_by_user_id,
         task::update_status_task,
+        task::get_task_stats_year
     ]
 }
 

--- a/backend/src/routes/mod.rs
+++ b/backend/src/routes/mod.rs
@@ -32,7 +32,8 @@ pub fn get_task_routes() -> Vec<rocket::Route> {
         task::delete_task,
         task::get_tasks_by_user_id,
         task::update_status_task,
-        task::get_task_stats_year
+        task::get_task_stats_year,
+        task::get_task_stats_month
     ]
 }
 

--- a/backend/src/service/auth_service.rs
+++ b/backend/src/service/auth_service.rs
@@ -1,11 +1,8 @@
-use sea_orm::ColumnTrait;
-use sea_orm::QueryFilter;
 use crate::db::Pool;
 use crate::dto::authDTO::AuthDto;
 use crate::repository::auth_repository::{self, UserError};
 use crate::entity::user;
 use rocket::State;
-//use sea_orm::EntityTrait;
 
 pub async fn register_user(
     db: &State<Pool>,

--- a/backend/src/service/reminder_service.rs
+++ b/backend/src/service/reminder_service.rs
@@ -4,7 +4,6 @@ use crate::db::Pool;
 use crate::dto::reminder_dto::reminder_DTO;
 use crate::entity::reminder;
 use rocket::http::Status;
-use sea_orm::prelude::DateTimeUtc;
 use sea_orm::QueryFilter;
  use sea_orm::ColumnTrait;
 

--- a/backend/src/service/task_service.rs
+++ b/backend/src/service/task_service.rs
@@ -60,7 +60,32 @@ pub async fn get_task_stats_year_db(
         "total_tasks": total_tasks,
         "executed_tasks": executed_tasks,
         "percentage": format!("{:.2}", percentage),
-        "period": year,
+        "year": year,
+        "most_productive_shift": most_productive_shift,
+        "most_used_category": most_used_category
+    }))
+}
+
+pub async fn get_task_stats_month_db(
+    db: &State<Pool>,
+    user_id: i32,
+    year: i32,
+    month: i32,
+) -> Result<Value, TaskError> {
+    let conn = db.inner();
+    let repo = TaskRepository::new(conn);
+
+    let (total_tasks, executed_tasks, percentage, year, month, most_productive_shift, most_used_category) = repo
+        .tasks_stats_month(user_id, year, month)
+        .await
+        .map_err(|e| TaskError::DatabaseError(e.to_string()))?;
+
+    Ok(json!({
+        "total_tasks": total_tasks,
+        "executed_tasks": executed_tasks,
+        "percentage": format!("{:.2}", percentage),
+        "year": year,
+        "month": month,
         "most_productive_shift": most_productive_shift,
         "most_used_category": most_used_category
     }))

--- a/backend/src/service/task_service.rs
+++ b/backend/src/service/task_service.rs
@@ -5,7 +5,7 @@ use crate::entity::task;
 use crate::repository::task_repository::TaskRepository;
 use sea_orm::DeleteResult;
 use validator::Validate;
-
+use serde_json::{json, Value};
 /// Enum para erros específicos do serviço de tarefas.
 pub enum TaskError {
     TaskNotFound(String),
@@ -40,6 +40,30 @@ pub async fn get_tasks_by_user_id_db(
     repo.find_by_user_id(user_id)
         .await
         .map_err(|e| TaskError::DatabaseError(e.to_string()))
+}
+
+pub async fn get_task_stats_year_db(
+    db: &State<Pool>,
+    user_id: i32,
+    year: i32,
+
+) -> Result<Value, TaskError> {
+    let conn = db.inner();
+    let repo = TaskRepository::new(conn);
+
+    let (total_tasks, executed_tasks, percentage, year, most_productive_shift, most_used_category) = repo
+        .tasks_stats_year(user_id, year)
+        .await
+        .map_err(|e| TaskError::DatabaseError(e.to_string()))?;
+
+    Ok(json!({
+        "total_tasks": total_tasks,
+        "executed_tasks": executed_tasks,
+        "percentage": format!("{:.2}", percentage),
+        "period": year,
+        "most_productive_shift": most_productive_shift,
+        "most_used_category": most_used_category
+    }))
 }
 pub async fn register_task_db(
     db: &State<Pool>,


### PR DESCRIPTION
This pull request adds new endpoints and logic to provide yearly and monthly statistics for user tasks, including total and executed tasks, completion percentage, most productive shift, and most used category. It also updates the task type logic and improves code organization by cleaning up imports and dependencies.

**Task statistics features:**

* Added two new endpoints in `backend/src/controller/task.rs` to retrieve yearly and monthly task statistics for a user (`get_task_stats_year` and `get_task_stats_month`). [[1]](diffhunk://#diff-64bf92862d1bc40bff1c92d2dde5037bc03eabc0492602eb1f1a3f7936e69226R47-R81) [[2]](diffhunk://#diff-c1e65a74d6ea32a6e5040fa66f4e5f4b4aa596c178d1c99438659e69723da6ccR35-R36)
* Implemented repository methods in `backend/src/repository/task_repository.rs` to calculate statistics such as total tasks, executed tasks, completion percentage, most productive shift (by time of day), and most used category, for both year and month queries.
* Added corresponding service methods in `backend/src/service/task_service.rs` to format and return these statistics as JSON responses.

**Task type and time logic updates:**

* Updated the `task` entity and repository logic to support new task types (`DuasHoras`, `Madrugada`) and refined the time ranges for existing types (`Manha`, `Tarde`, etc.). [[1]](diffhunk://#diff-dbf655c91522cd9c125772159ea39375866c05c8dd182521b1edc48dea3ab696L18-R18) [[2]](diffhunk://#diff-895c6c94050ad76845b46260cac543c286374015b86589da53c339d6dcddf2e3R226-R245)

**Codebase and dependency cleanup:**

* Removed unused imports and dependencies across several files, and added the `serde_json` crate for JSON handling. [[1]](diffhunk://#diff-abf5cd6f388506566c1841d733a56009055b4b8819f149301a42ec28e8555da1R21) [[2]](diffhunk://#diff-e460c6d564a7bd6db867b30da274f353fd193c3bcfa7d750293405691408e7b0L4-L5) [[3]](diffhunk://#diff-64bf92862d1bc40bff1c92d2dde5037bc03eabc0492602eb1f1a3f7936e69226R3-R9) [[4]](diffhunk://#diff-a0cf47424e5a7e44f1d513437af256ba181b09f81e3b9a658bbdacea43302554L1-R1) [[5]](diffhunk://#diff-03f0e815a03d93163cd4716a8ce1b5721eb199510b81334e5f5c1ae63af4704dL12-R14) [[6]](diffhunk://#diff-bd9656da13eea6e7356d2c6f888dadbfdb0d63fc3409100602d586c522cfd705L1-L8) [[7]](diffhunk://#diff-4449da8448ee731e4ce25bb78a56eca808f588da97b06c6b60168250b288c6d6L7) [[8]](diffhunk://#diff-ddb24268bdb43ec3e338a137d6d193bd90cd3efdda855df8ca7e81fd3e0c6039L8-R8)