### PR TITLE
feat: Finishing task updating with button to complete

### DIFF
--- a/backend/src/repository/task_repository.rs
+++ b/backend/src/repository/task_repository.rs
@@ -475,7 +475,7 @@ impl<'a> TaskRepository<'a> {
 
         let status = if let Some(status) = &task_info.status {
             match status.as_str() {
-                "Executada" | "Adiada" => Ok(status.clone()),
+                "Concluída" | "Adiada" | "Pendente" => Ok(status.clone()),
                 _ => Err(DbErr::Custom(format!("Status inválido: {}", status))),
             }?
         } else {

--- a/frontend/src/components/task_card.rs
+++ b/frontend/src/components/task_card.rs
@@ -47,6 +47,7 @@ pub struct TaskCardProps {
     pub status: String,
     pub on_task_delete: Callback<u32>,
     pub on_task_update: Option<Callback<(u32, String, String)>>, // (id, title, description)
+    pub on_status_update: Option<Callback<(u32, String)>>, // (id, new_status)
 }
 
 #[function_component(TaskCard)]
@@ -129,6 +130,26 @@ pub fn task_card(props: &TaskCardProps) -> Html {
         })
     };
 
+    let on_status_toggle = {
+        let on_status_update = props.on_status_update.clone();
+        let task_id = props.id;
+        let current_status = props.status.clone();
+        Callback::from(move |e: MouseEvent| {
+            e.prevent_default();
+            e.stop_propagation();
+            
+            let new_status = if current_status.to_lowercase() == "pendente" {
+                "Concluída".to_string()
+            } else {
+                "Pendente".to_string()
+            };
+            
+            if let Some(callback) = &on_status_update {
+                callback.emit((task_id, new_status));
+            }
+        })
+    };
+
     let task_id = props.id;
     let on_delete_click = {
         let on_task_delete = props.on_task_delete.clone();
@@ -191,10 +212,18 @@ pub fn task_card(props: &TaskCardProps) -> Html {
                 }
                 <div class="task-datetime">
                     <span class="task-date">{ format!("Due Date: {}", &props.date) }</span>
-                    // if *show_info {
-                        <span class="task-time">{ format_time_display(&props.time, &props.duration) }</span>
-                    // }
+                    <span class="task-time">{ format_time_display(&props.time, &props.duration) }</span>
                 </div>
+                if *show_info {
+                    <div class="task-status-actions">
+                        <button 
+                            class={if props.status.to_lowercase() == "pendente" { "complete-button" } else { "incomplete-button" }}
+                            onclick={on_status_toggle}
+                        >
+                            { if props.status.to_lowercase() == "pendente" { "Completar" } else { "Descompletar" } }
+                        </button>
+                    </div>
+                }
             </div>
         </div>
     }

--- a/frontend/src/components/task_form.rs
+++ b/frontend/src/components/task_form.rs
@@ -332,7 +332,7 @@ pub fn task_form(props: &TaskFormProps) -> Html {
 
                         // Buttons - full width
                         <div class="button-container">
-                            <button type="submit" onclick={on_create}>{"Criar Task"}</button>
+                            <button type="submit" onclick={on_create}>{"Criar"}</button>
                             <button type="button" onclick={on_close}>{"Cancelar"}</button>
                         </div>
 

--- a/frontend/src/services/tasks.rs
+++ b/frontend/src/services/tasks.rs
@@ -125,3 +125,72 @@ pub async fn create_task(task_info: &TaskDto) -> TaskResult {
         Err(e) => TaskResult::NetworkError(e.to_string()),
     }
 }
+
+pub async fn update_task(task_id: u32, title: String, description: String) -> Result<(), String> {
+    let url = format!("{}/tasks/{}", API_URL, task_id);
+    let token = get_token();
+    if token.token.is_empty() {
+        return Err("No authentication token found".to_string());
+    }
+
+    #[derive(Serialize)]
+    struct UpdateTaskRequest {
+        title: String,
+        description: String,
+    }
+
+    let update_data = UpdateTaskRequest {
+        title,
+        description,
+    };
+
+    match Request::put(&url)
+        .header("Authorization", &format!("Bearer {}", token.token))
+        .header("Content-Type", "application/json")
+        .json(&update_data)
+        .unwrap()
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if response.status() == 200 || response.status() == 204 {
+                Ok(())
+            } else {
+                let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+                let error_msg = format!("Failed to update task: HTTP {} - {}", response.status(), error_text);
+                web_sys::console::log_1(&error_msg.clone().into());
+                Err(error_msg)
+            }
+        }
+        Err(e) => Err(format!("Network error: {}", e)),
+    }
+}
+
+pub async fn update_task_with_dto(task_id: u32, task_dto: TaskDto) -> Result<(), String> {
+    let url = format!("{}/tasks/{}", API_URL, task_id);
+    let token = get_token();
+    if token.token.is_empty() {
+        return Err("No authentication token found".to_string());
+    }
+
+    match Request::put(&url)
+        .header("Authorization", &format!("Bearer {}", token.token))
+        .header("Content-Type", "application/json")
+        .json(&task_dto)
+        .unwrap()
+        .send()
+        .await
+    {
+        Ok(response) => {
+            if response.status() == 200 || response.status() == 204 {
+                Ok(())
+            } else {
+                let error_text = response.text().await.unwrap_or_else(|_| "Unknown error".to_string());
+                let error_msg = format!("Failed to update task with DTO: HTTP {} - {}", response.status(), error_text);
+                web_sys::console::log_1(&error_msg.clone().into());
+                Err(error_msg)
+            }
+        }
+        Err(e) => Err(format!("Network error: {}", e)),
+    }
+}

--- a/frontend/src/services/tasks.rs
+++ b/frontend/src/services/tasks.rs
@@ -15,6 +15,14 @@ pub struct TaskDto {
     pub task_type: String,
 }
 
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct TaskUpdateDto {
+    pub title: String,
+    pub description: String,
+    pub status: String,
+}
+
 pub enum TaskResult {
     Success(Task),
     InvalidFields,
@@ -166,7 +174,7 @@ pub async fn update_task(task_id: u32, title: String, description: String) -> Re
     }
 }
 
-pub async fn update_task_with_dto(task_id: u32, task_dto: TaskDto) -> Result<(), String> {
+pub async fn update_task_with_dto(task_id: u32, task_dto: TaskUpdateDto) -> Result<(), String> {
     let url = format!("{}/tasks/{}", API_URL, task_id);
     let token = get_token();
     if token.token.is_empty() {

--- a/frontend/styles/_task-card.scss
+++ b/frontend/styles/_task-card.scss
@@ -330,3 +330,96 @@
   outline: 1px dotted #000000;
   outline-offset: 1px;
 }
+
+// Edit mode styles
+.task-title-input {
+  font-size: 11px;
+  font-weight: bold;
+  color: #000000;
+  margin: 0;
+  padding: 2px 4px;
+  background: #ffffff;
+  border: 1px inset #c0c0c0;
+  border-radius: 0;
+  font-family: "MS Sans Serif", sans-serif;
+  width: 100%;
+  box-sizing: border-box;
+  
+  &:focus {
+    outline: 1px dotted #000000;
+    outline-offset: 1px;
+  }
+}
+
+.task-description-input {
+  font-size: 11px;
+  color: #000000;
+  line-height: 1.2;
+  margin: 0 0 4px 0;
+  padding: 4px;
+  background: #ffffff;
+  border: 1px inset #c0c0c0;
+  border-radius: 0;
+  font-family: "MS Sans Serif", sans-serif;
+  width: 100%;
+  box-sizing: border-box;
+  min-height: 60px;
+  resize: vertical;
+  word-wrap: break-word;
+  
+  &:focus {
+    outline: 1px dotted #000000;
+    outline-offset: 1px;
+  }
+}
+
+.save-button,
+.cancel-button {
+  padding: 1px 4px;
+  font-size: 9px;
+  font-weight: normal;
+  border-radius: 0;
+  cursor: pointer;
+  transition: none;
+  min-width: auto;
+  margin: 0;
+  font-family: "MS Sans Serif", sans-serif;
+  
+  &:hover {
+    transform: none;
+  }
+  
+  &:active {
+    transform: none;
+  }
+}
+
+.save-button {
+  background: #90ee90;
+  border: 1px outset #90ee90;
+  color: #000000;
+  
+  &:hover {
+    background: #98fb98;
+  }
+  
+  &:active {
+    border: 1px inset #90ee90;
+    background: #7ccd7c;
+  }
+}
+
+.cancel-button {
+  background: #ffb6c1;
+  border: 1px outset #ffb6c1;
+  color: #000000;
+  
+  &:hover {
+    background: #ffc0cb;
+  }
+  
+  &:active {
+    border: 1px inset #ffb6c1;
+    background: #f08080;
+  }
+}

--- a/frontend/styles/_task-card.scss
+++ b/frontend/styles/_task-card.scss
@@ -244,6 +244,50 @@
   overflow-wrap: break-word;
 }
 
+// Status action buttons
+.task-status-actions {
+  margin-top: 8px;
+  display: flex;
+  justify-content: center;
+}
+
+.complete-button,
+.incomplete-button {
+  font-family: "MS Sans Serif", sans-serif;
+  font-size: 11px;
+  padding: 4px 12px;
+  border: 1px outset #c0c0c0;
+  background: #c0c0c0;
+  color: #000000;
+  cursor: pointer;
+  
+  &:hover {
+    background: #d4d0c8;
+    border: 1px outset #d4d0c8;
+  }
+  
+  &:active {
+    border: 1px inset #c0c0c0;
+    background: #b8b8b8;
+  }
+}
+
+.complete-button {
+  // Green accent for complete action
+  &:hover {
+    background: #90EE90;
+    border: 1px outset #90EE90;
+  }
+}
+
+.incomplete-button {
+  // Orange accent for incomplete action
+  &:hover {
+    background: #FFB347;
+    border: 1px outset #FFB347;
+  }
+}
+
 // Windows 98 style - no theme variations needed
 .dark-theme .task-card,
 .light-theme .task-card {


### PR DESCRIPTION
This pull request introduces in-place editing and status toggling for tasks in the calendar app, along with backend and frontend support for updating tasks. It adds new APIs and UI elements to allow users to edit task titles and descriptions directly from the task card, as well as to mark tasks as complete or incomplete. The backend is updated to handle new status values and the frontend receives new styles for the enhanced task card interactions.

**Frontend enhancements for task editing and status management:**

* Added in-place editing of task titles and descriptions in `TaskCard`, including edit, save, and cancel buttons, and connected these actions to backend update APIs. Also added status toggle buttons to mark tasks as complete/incomplete, with corresponding callbacks and UI feedback. (`frontend/src/components/task_card.rs`, `frontend/src/components/calendar_app.rs`, `frontend/styles/_task-card.scss`) [[1]](diffhunk://#diff-00c824971bab311f190bf896863469e77ad1d223d1f3599d0b422b58864b66a0R49-R149) [[2]](diffhunk://#diff-00c824971bab311f190bf896863469e77ad1d223d1f3599d0b422b58864b66a0R167-R226) [[3]](diffhunk://#diff-dc2a77ae75b7afb78f48b7fb0584dc655398ec189e201ef2773b8ec16ca38cebR117-R159) [[4]](diffhunk://#diff-dc2a77ae75b7afb78f48b7fb0584dc655398ec189e201ef2773b8ec16ca38cebR200-R234) [[5]](diffhunk://#diff-dc2a77ae75b7afb78f48b7fb0584dc655398ec189e201ef2773b8ec16ca38cebR528-R529) [[6]](diffhunk://#diff-eb792162c51abd02116c7a952457a84e58619a2b509de529bfd2c169d7a9cfebR247-R290) [[7]](diffhunk://#diff-eb792162c51abd02116c7a952457a84e58619a2b509de529bfd2c169d7a9cfebR377-R469)

* Updated the task form's create button label to a more concise "Criar". (`frontend/src/components/task_form.rs`)

**Backend and API changes:**

* Added a new `TaskUpdateDto` struct and corresponding API endpoint functions to update tasks with title, description, and status. This allows granular updates from the frontend. (`frontend/src/services/tasks.rs`) [[1]](diffhunk://#diff-231f207fe62158b0e86a1cde253645cbc00b85d47208818aa232a06b837de930R18-R25) [[2]](diffhunk://#diff-231f207fe62158b0e86a1cde253645cbc00b85d47208818aa232a06b837de930R136-R204)

* Expanded allowed status values in the backend to include "Concluída", "Adiada", and "Pendente", improving status management consistency. (`backend/src/repository/task_repository.rs`)

**Styling improvements:**

* Introduced new styles for task card edit mode, including input fields and action buttons for editing, saving, canceling, and toggling status, with clear visual feedback for each action. (`frontend/styles/_task-card.scss`) [[1]](diffhunk://#diff-eb792162c51abd02116c7a952457a84e58619a2b509de529bfd2c169d7a9cfebR247-R290) [[2]](diffhunk://#diff-eb792162c51abd02116c7a952457a84e58619a2b509de529bfd2c169d7a9cfebR377-R469)