### PR TITLE
Filter goals to show only those with a date_end today or in the future

### DIFF
--- a/frontend/src/components/calendar_app.rs
+++ b/frontend/src/components/calendar_app.rs
@@ -745,13 +745,25 @@ pub fn calendar_app(props: &CalendarAppProps) -> Html {
                             html! { <>{reminder_cards}</> }
                         },
                              ViewType::Goals => {
-                                let goal_cards: Vec<Html> = goals.iter().map(|goal| {
+                                // Only show goals whose date_end is today or in the future (date_end >= selected_date)
+                                let selected_date = NaiveDate::from_ymd_opt(*current_year, *current_month, *selected_day)
+                                    .unwrap_or_else(|| Local::now().date_naive());
+                                let filtered_goals: Vec<&Goal> = goals.iter()
+                                    .filter(|goal| {
+                                        if let Ok(date_end) = chrono::NaiveDate::parse_from_str(&goal.date_end, "%Y-%m-%d") {
+                                            date_end >= selected_date
+                                        } else {
+                                            false
+                                        }
+                                    })
+                                    .collect();
+
+                                let goal_cards: Vec<Html> = filtered_goals.iter().map(|goal| {
                                     let on_edit_goal = on_edit_goal.clone();
-                                    let goal_clone_for_edit = goal.clone();
+                                    let goal_clone_for_edit = (*goal).clone();
                                     html! {
                                         <GoalCard
                                             key={goal.id}
-                                            // ...todas as props do goal
                                             id={goal.id}
                                             name={goal.name.clone()}
                                             description={goal.description.clone()}


### PR DESCRIPTION
This pull request updates the logic for displaying goal cards in the calendar app, ensuring that only relevant goals are shown to the user. The main change filters the list of goals so that only those whose end date is today or in the future are displayed.

Filtering and display improvements:

* Modified the `calendar_app` component in `calendar_app.rs` to filter goals by their `date_end` field, showing only those with an end date on or after the selected date. This is done by parsing the `date_end` string and comparing it to the currently selected date.
* Updated the mapping logic to use the filtered goals when rendering goal cards, ensuring that only valid goals are shown in the UI.